### PR TITLE
Create a "Getting Started" page to display on first installation

### DIFF
--- a/main/res/layout/about_starting_page.xml
+++ b/main/res/layout/about_starting_page.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="vertical"
+    android:padding="4dip"
+    tools:context=".AboutActivity$StartingViewCreator" >
+
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" >
+
+        <TextView
+            android:id="@+id/about_starting_head"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_margin="7dip"
+            android:paddingLeft="3dip"
+            android:text="@string/about_starting_head"
+            android:textColor="?text_color_headline"
+            android:textStyle="bold"
+            android:textSize="16sp" />
+
+        <TextView
+            android:id="@+id/about_starting_text_basics_head"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:layout_margin="7sp"
+            android:paddingLeft="3dip"
+            android:text="@string/about_starting_text_basics_head"
+            android:textColor="?text_color_headline"
+            android:textStyle="bold"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/about_starting_text_basics_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:layout_margin="7sp"
+            android:autoLink="web"
+            android:paddingLeft="3dip"
+            android:text="@string/about_starting_text_basics_text"
+            android:textColor="?text_color"
+            android:textColorLink="?text_color_link"
+            android:textSize="12sp" />
+
+        <TextView
+            android:id="@+id/about_starting_text_device_head"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:layout_margin="7sp"
+            android:paddingLeft="3dip"
+            android:text="@string/about_starting_text_device_head"
+            android:textColor="?text_color_headline"
+            android:textStyle="bold"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/about_starting_text_device_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:layout_margin="7sp"
+            android:autoLink="web"
+            android:paddingLeft="3dip"
+            android:text="@string/about_starting_text_device_text"
+            android:textColor="?text_color"
+            android:textColorLink="?text_color_link"
+            android:textSize="12sp" />
+
+        <TextView
+            android:id="@+id/about_starting_text_first_head"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:layout_margin="7sp"
+            android:paddingLeft="3dip"
+            android:text="@string/about_starting_text_first_head"
+            android:textColor="?text_color_headline"
+            android:textStyle="bold"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/about_starting_text_first_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:layout_margin="7sp"
+            android:autoLink="web"
+            android:paddingLeft="3dip"
+            android:text="@string/about_starting_text_first_text"
+            android:textColor="?text_color"
+            android:textColorLink="?text_color_link"
+            android:textSize="12sp" />
+
+        <Button
+            android:id="@+id/about_starting_btn_services"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="?text_color"
+            android:text="@string/open_services_page"
+            android:padding="12dp"  />
+    </LinearLayout>
+
+</ScrollView>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -441,6 +441,27 @@
     <string name="about_license">License</string>
     <string name="about_apache_license"><a href="">Apache License, Version 2.0</a></string>
     <string name="about_help">Help</string>
+    <string name="about_starting">Getting Started</string>
+    <string name="about_starting_head">Getting Started</string>
+    <string name="about_starting_text_basics_head">Geocaching basics</string>
+    <string name="about_starting_text_basics_text">
+Geocaching is an outdoor game to search and find so-called \"caches\".\n
+This app helps you to play this game.\n\n
+Link to the full <b>c:geo basics</b> documentation: https://manual.cgeo.org/en/basicuse
+    </string>
+    <string name="about_starting_text_device_head">c:geo device permissions</string>
+    <string name="about_starting_text_device_text">
+c:geo needs certain permissions on your device: <b>Location</b> and <b>Photos/Media/Files</b>.\n
+You have to confirm to use the app.\n\n
+Details are in the <b>c:geo permission</b> documentation: https://manual.cgeo.org/en/installation#permissions
+    </string>
+    <string name="about_starting_text_first_head">First steps with c:geo</string>
+    <string name="about_starting_text_first_text">
+In order to use c:geo, you need an account for a geocaching platform of your choice.\n
+You can configure it from our services page.\n\n
+Link to the full <b>c:geo First steps</b> documentation: https://manual.cgeo.org/en/firststeps
+    </string>
+    <string name="open_services_page">Configure your platform selection</string>
     <string name="about_system_include">Please include the following system information when sending a bug report or asking for more information about c:geo:</string>
     <string name="about_system_info_send_button">Send by mail…</string>
     <string name="about_system_info">c:geo system information</string>
@@ -482,7 +503,8 @@
     <string name="settings_title_navigation_menu">Navigation Menu</string>
 
     <string name="settings_category_browser">Browser</string>
-    <string name="settings_category_geocaching">Geocaching</string>
+    <string name="settings_category_geocaching_platform">Geocaching Platform</string>
+    <string name="settings_category_geocaching_additionals">Further services and addon</string>
     <string name="settings_category_social">Social media</string>
     <string name="settings_category_logging_other">Other Logging Options</string>
 

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -8,7 +8,7 @@
         android:key="@string/preference_screen_services"
         android:summary="@string/settings_summary_services"
         android:title="@string/settings_title_services" >
-        <PreferenceCategory android:title="@string/settings_category_geocaching"
+        <PreferenceCategory android:title="@string/settings_category_geocaching_platform"
             android:layout="@layout/preference_category" >
 
             <PreferenceScreen
@@ -323,6 +323,10 @@
                         app:connector="SU" />
                 </PreferenceCategory>
             </PreferenceScreen>
+        </PreferenceCategory>
+
+        <PreferenceCategory android:title="@string/settings_category_geocaching_additionals"
+            android:layout="@layout/preference_category" >
 
             <PreferenceScreen
                 android:key="@string/preference_screen_gcvote"

--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -183,6 +183,27 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
 
     }
 
+    class StartingViewCreator extends AbstractCachingPageViewCreator<ScrollView> {
+
+        @BindView(R.id.about_starting_btn_services) protected Button services;
+
+        @Override
+        public ScrollView getDispatchedView(final ViewGroup parentView) {
+            final ScrollView view = (ScrollView) getLayoutInflater().inflate(R.layout.about_starting_page, parentView, false);
+            ButterKnife.bind(this, view);
+
+            services.setOnClickListener(new OnClickListener() {
+
+                @Override
+                public void onClick(final View v) {
+                    //TODO implement jump to Services->Platform page
+                }
+            });
+            return view;
+        }
+
+    }
+
     class VersionViewCreator extends AbstractCachingPageViewCreator<ScrollView> {
 
         @BindView(R.id.about_version_string) protected TextView version;
@@ -206,6 +227,7 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
     enum Page {
         VERSION(R.string.about_version),
         HELP(R.string.about_help),
+        STARTING(R.string.about_starting),
         CHANGELOG(R.string.about_changelog),
         SYSTEM(R.string.about_system),
         CONTRIBUTORS(R.string.about_contributors),
@@ -253,6 +275,8 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
                 return new VersionViewCreator();
             case HELP:
                 return new HelpViewCreator();
+            case STARTING:
+                return new StartingViewCreator();
             case CHANGELOG:
                 return new ChangeLogViewCreator();
             case SYSTEM:
@@ -279,6 +303,12 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
     public static void showChangeLog(final Activity fromActivity) {
         final Intent intent = new Intent(fromActivity, AboutActivity.class);
         intent.putExtra(EXTRA_ABOUT_STARTPAGE, Page.CHANGELOG.ordinal());
+        fromActivity.startActivity(intent);
+    }
+
+    public static void showStarting(final Activity fromActivity) {
+        final Intent intent = new Intent(fromActivity, AboutActivity.class);
+        intent.putExtra(EXTRA_ABOUT_STARTPAGE, Page.STARTING.ordinal());
         fromActivity.startActivity(intent);
     }
 

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -283,7 +283,7 @@ public class MainActivity extends AbstractActionBarActivity {
 
         init();
 
-        checkShowChangelog();
+        checkChangedInstall();
 
         LocalStorage.initGeocacheDataDir();
         if (LocalStorage.isRunningLowOnDiskSpace()) {
@@ -786,16 +786,23 @@ public class MainActivity extends AbstractActionBarActivity {
         startActivity(new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS));
     }
 
-    private void checkShowChangelog() {
+    private void checkChangedInstall() {
         // temporary workaround for #4143
         //TODO: understand and avoid if possible
         try {
             final long lastChecksum = Settings.getLastChangelogChecksum();
             final long checksum = TextUtils.checksum(getString(R.string.changelog_master) + getString(R.string.changelog_release));
             Settings.setLastChangelogChecksum(checksum);
-            // don't show change log after new install...
-            if (lastChecksum > 0 && lastChecksum != checksum) {
-                AboutActivity.showChangeLog(this);
+
+            // show starting page after install
+            AboutActivity.showChangeLog(this);
+            if (lastChecksum == 0) {
+                AboutActivity.showStarting(this);
+            } else {
+                // show change log page after update
+                if (lastChecksum != checksum) {
+                    AboutActivity.showChangeLog(this);
+                }
             }
         } catch (final Exception ex) {
             Log.e("Error checking/showing changelog!", ex);


### PR DESCRIPTION
fix#4263 (1st impression in application is bad)

As before discussed in #7461 now separated the idea for an initial welcome screen.

I have created a "Getting Started" page that is displayed to the user the first time c:geo start after installation.
It is located in the "about c:geo" section, so the user can read it also later.
The initial text is split in 3 section - general, permission and platform information.
This could be extended if necessary, e.g. in German language to https://www.cachewiki.de/wiki/Hauptseite.

The page is presented before the permissions questions (on map access).